### PR TITLE
print local IP address on "versal preview"

### DIFF
--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -53,8 +53,8 @@ commands =
     preview dirs, argv, (err, projects) ->
       if err then return logError err
 
-      localIPOrNull = require('./local-ip')()
-      localIpString = if localIPOrNull then " or http://#{localIPOrNull}:#{argv.port}" else ""
+      localIp = require('./local-ip')()
+      localIpString = if localIp then " or http://#{localIp}:#{argv.port}" else ""
       console.log chalk.green("\\\\\\  ///  versal #{pkg.version}")
       console.log chalk.yellow(" \\\\\\///   http://localhost:#{argv.port}#{localIpString}")
       console.log chalk.red("  \\\\\\/    ctrl + C to stop")

--- a/src/local-ip.coffee
+++ b/src/local-ip.coffee
@@ -1,10 +1,10 @@
 # Function to get the local IP address.
 # Looks for the first IPv4 address that is not internal.
-# Returns null if nothing is found.
+# Returns undefined if nothing is found.
 
 module.exports = () ->
   ifaces = require('os').networkInterfaces()
   for ifaceName, ifaceGroup of ifaces
     for iface in ifaceGroup
       if !iface.internal && (iface.family == 'IPv4') then return iface.address
-  null
+  return


### PR DESCRIPTION
"versal publish" now prints local IP address if found, to facilitate local testing

This is a first step. Local testing should be always easily available, but may not always work correctly. (The second step is to publish a standalone iframe launcher somewhere on versal.io.)
