### PR TITLE
Bump SDK version to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.5.0
+
+  * Bump Player to 1.5.2 (from now on we'll keep the SDK minor version in sync with the player minor version)
+
+---
+
 # v0.6.3
 
   * Add Travis CI

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "versal-sdk",
   "description": "Versal Gadget SDK with command-line interface.",
-  "version": "0.6.3",
+  "version": "1.5.0",
   "author": "Versal team <support@versal.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Proposal: keep minor version of SDK in line with minor version of the player. Let’s not do patch versions also, so we can still do fixes without having to bump the player version.

This means that significant fixes in the player (minor version bump) will also be reflected as a significant fix in the SDK.

@Aaronik @mereskin 
