### PR TITLE
Only save data that we need to save.

### DIFF
--- a/src/local-api/gadgets.coffee
+++ b/src/local-api/gadgets.coffee
@@ -18,7 +18,7 @@ gadgets.get '/courses/:courseid/lessons/:lessonid/gadgets/:gadgetid', (req, res)
   res.json req.gadget
 
 gadgets.post '/courses/:courseid/lessons/:lessonid/gadgets', (req, res) ->
-  gadget = req.body
+  gadget = _.pick req.body, 'config', 'userState', 'index', 'type'
   gadget.id = shortid()
   req.lesson.gadgets.push gadget
   res.send 201, gadget


### PR DESCRIPTION
Not, say, isEditing. Solves problem where clicking on the gear icon didn’t bring the gadget in editing mode.
