### PR TITLE
The rest-api doesn’t send back responses, so we also shouldn’t do that in our local API.

### DIFF
--- a/src/local-api/gadgets.coffee
+++ b/src/local-api/gadgets.coffee
@@ -29,11 +29,11 @@ gadgets.delete '/courses/:courseid/lessons/:lessonid/gadgets/:gadgetid', (req, r
 
 gadgets.put '/courses/:courseid/lessons/:lessonid/gadgets/:gadgetid/config', (req, res) ->
   req.gadget.config = req.body
-  res.json req.gadget.config
+  res.json {}
 
 gadgets.put '/courses/:courseid/lessons/:lessonid/gadgets/:gadgetid/userstate', (req, res) ->
   req.gadget.userState = req.body
-  res.send req.gadget.userState
+  res.send {}
 
 gadgets.get '/courses/:courseid/lessons/:lessonid/gadgets/:gadgetid/userstate', (req, res) ->
   res.send req.gadget.userState

--- a/test/api_spec.coffee
+++ b/test/api_spec.coffee
@@ -121,9 +121,11 @@ describe 'Local API', ->
         .send(content: 'Updated content')
         .expect 200, (err, res) ->
           if err then return done err
-          res.body.content.should.eq 'Updated content'
-          res.body.should.eql gadgets()[0].config
-          done()
+          request(api).get('/courses/local/lessons/1/gadgets/' + newGadgetId)
+            .expect 200, (err, res) ->
+              if err then return done err
+              res.body.config.content.should.eq 'Updated content'
+              done()
 
     it 'removes config values', (done) ->
       request(api).put('/courses/local/lessons/1/gadgets/' + newGadgetId + '/config')
@@ -138,9 +140,11 @@ describe 'Local API', ->
         .send(x: 73)
         .expect 200, (err, res) ->
           if err then return done err
-          res.body.x.should.eq 73
-          res.body.should.eql gadgets()[0].userState
-          done()
+          request(api).get('/courses/local/lessons/1/gadgets/' + newGadgetId + '/userstate')
+            .expect 200, (err, res) ->
+              if err then return done err
+              res.body.x.should.eq 73
+              done()
 
     it 'removes userstate values', (done) ->
       request(api).put('/courses/local/lessons/1/gadgets/' + newGadgetId + '/userstate')


### PR DESCRIPTION
This makes it easier to debug locally.
