### PR TITLE
Add PUT /courses/id/lessons/id/gadgets/order endpoint.

### DIFF
--- a/src/local-api/gadgets.coffee
+++ b/src/local-api/gadgets.coffee
@@ -6,6 +6,8 @@ gadgets = express()
 
 gadgets.load = (req, res, next) ->
   id = req.param('gadgetid')
+  return next() if id == 'order'
+
   if id && req.lesson
     req.gadget = _.findWhere req.lesson.gadgets, { id }
   if !req.gadget then return res.send 404, "Gadget not found"
@@ -13,6 +15,9 @@ gadgets.load = (req, res, next) ->
 
 gadgets.get '/courses/:courseid/lessons/:lessonid/gadgets', (req, res) ->
   res.json req.lesson.gadgets
+
+gadgets.put '/courses/:courseid/lessons/:lessonid/gadgets/order', (req, res) ->
+  res.json {}
 
 gadgets.get '/courses/:courseid/lessons/:lessonid/gadgets/:gadgetid', (req, res) ->
   res.json req.gadget

--- a/test/api_spec.coffee
+++ b/test/api_spec.coffee
@@ -116,6 +116,11 @@ describe 'Local API', ->
       request(api).get('/courses/local/lessons/1/gadgets/' + newGadgetId)
         .expect 200, done
 
+    it 'order', (done) ->
+      request(api).put('/courses/local/lessons/1/gadgets/order')
+        .send(['foo','bar'])
+        .expect 200, done
+
     it 'updates config values', (done) ->
       request(api).put('/courses/local/lessons/1/gadgets/' + newGadgetId + '/config')
         .send(content: 'Updated content')


### PR DESCRIPTION
It doesn't really do anything, just returns 200.

Just to avoid console errors when reordering gadgets locally.
