### PR TITLE
Wait for HTML imports to load before instantiating a gadget

### DIFF
--- a/templates/minimal/versal.html
+++ b/templates/minimal/versal.html
@@ -22,36 +22,39 @@ input[readonly] {
 </body>
 
 <script>
-var greeting = document.querySelector('[name=greeting]');
-var learnerName = document.querySelector('[name=learnerName]');
-var player = new VersalPlayerAPI();
+window.addEventListener('HTMLImportsLoaded', function(){
 
-greeting.addEventListener('change', function(e){
-  player.setAttribute(greeting.name, greeting.value);
+  var greeting = document.querySelector('[name=greeting]');
+  var learnerName = document.querySelector('[name=learnerName]');
+  var player = new VersalPlayerAPI();
+
+  greeting.addEventListener('change', function(e){
+    player.setAttribute(greeting.name, greeting.value);
+  });
+
+  learnerName.addEventListener('change', function(e){
+    player.setLearnerAttribute(learnerName.name, learnerName.value);
+  });
+
+  player.on('attributesChanged', function(data){
+    if(data.greeting) {
+      greeting.value = data.greeting;
+    };
+  });
+
+  player.on('learnerStateChanged', function(data){
+    if(data.learnerName) {
+      learnerName.value = data.learnerName;
+    };
+  });
+
+  player.on('editableChanged', function(editable){
+    greeting.readOnly = !editable.editable;
+    learnerName.readOnly = editable.editable;
+  });
+
+  player.setHeight(60);
+  player.startListening();
 });
-
-learnerName.addEventListener('change', function(e){
-  player.setLearnerAttribute(learnerName.name, learnerName.value);
-});
-
-player.on('attributesChanged', function(data){
-  if(data.greeting) {
-    greeting.value = data.greeting;
-  };
-});
-
-player.on('learnerStateChanged', function(data){
-  if(data.learnerName) {
-    learnerName.value = data.learnerName;
-  };
-});
-
-player.on('editableChanged', function(editable){
-  greeting.readOnly = !editable.editable;
-  learnerName.readOnly = editable.editable;
-});
-
-player.setHeight(60);
-player.startListening();
 </script>
 </html>


### PR DESCRIPTION
> there seems to be a bug in the Versal SDK's preview function using Firefox 32.0.3 for Mac (I also replicated it with all of my add-ons disabled). If you create a new gadget (and don't make any changes to it), run and load the preview, and then, in the course, add "My Gadget", you get the following error: "ReferenceError: VersalPlayerAPI is not defined". This all works just fine on Chrome.
