### PR TITLE
Make versal-iframe-launcher a display block

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -16,6 +16,7 @@
     }
 
     versal-iframe-launcher, versal-iframe-launcher iframe {
+      display: block;
       height: 100%;
     }
     </style>


### PR DESCRIPTION
Fixes double scrollbars on SDK preview.
